### PR TITLE
1876839: Add CLI contributor role to code blocks

### DIFF
--- a/academic-services/knowledge-exploration-service/reference-makes-command-line-tool.md
+++ b/academic-services/knowledge-exploration-service/reference-makes-command-line-tool.md
@@ -499,7 +499,7 @@ The path to the azure credential file to use for authentication. If you're using
 You can generate this file using [Azure CLI 2.0](https://github.com/Azure/azure-cli) through the following command. Make sure you selected your subscription by `az account set --subscription <name or id>` and you have the privileges to create service principals.
 
 ```bash
-az ad sp create-for-rbac --sdk-auth > my.azureauth
+az ad sp create-for-rbac --role Contributor --sdk-auth > my.azureauth
 ```
 
 If you don't have Azure CLI installed, you can also do this in the [cloud shell](https://docs.microsoft.com/azure/cloud-shell/quickstart).


### PR DESCRIPTION
Default role: Contributor is being deprecated for az ad sp create-for-rbac. Added --role contributor to code blocks where the current role selection is left as default (no parameter).

User story [1876839](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1876839)